### PR TITLE
Omit appending 's' on 'Eins Uhr' to get 'Ein Uhr' on full hour

### DIFF
--- a/MMM-germanwordclock.js
+++ b/MMM-germanwordclock.js
@@ -60,6 +60,9 @@ Module.register("MMM-germanwordclock",{
 		this.elements["it"] = "it";
 		this.elements["is"] = "is";
 
+                // Adds the char 's' to 'ein'
+                this.elements["einS"] = "einS"
+
 		// Set Interval for Update
 		var self = this;
 		setInterval(function() {
@@ -118,6 +121,12 @@ Module.register("MMM-germanwordclock",{
 			elements.push("five","befor");
 			hour = (hour + 1) % 12;
 		}
+
+                // When we are using 'eins', add the 's' to 'ein'.
+                // Omit the 's', when we are saying 'es ist ein uhr'.
+                if (minute >= 4 && hour == 1) {
+                    elements.push("einS");
+                }
 
 
 		elements.push(this.setHour(hour));
@@ -182,7 +191,7 @@ Module.register("MMM-germanwordclock",{
 								"&nbsp;<span id=\"ten\">Z E H N</span> <span id=\"quarter\">V I E R T E L</span>&nbsp;<br />" +
 								"&nbsp;<span id=\"twenty\">Z W A N Z I G </span>S P Ä T&nbsp;<br />" +
                                 "&nbsp;<span id=\"befor\">V O R</span> N U L L <span id=\"past\">N A C H</span>&nbsp;<br />" +
-                                "&nbsp;<span id=\"half\">H A L B </span> T A U <span id=\"hour1\">E I N S</span>&nbsp;<br />" +
+                                "&nbsp;<span id=\"half\">H A L B </span> T A U <span id=\"hour1\">E I N </span><span id=\"einS\">S</span>&nbsp;<br />" +
                                 "&nbsp;<span id=\"hour4\">V I E R</span> S T <span id=\"hour12\">Z W Ö L F </span>&nbsp;<br />" +
 								"&nbsp;<span id=\"hour6\">S E C H S </span><span id=\"hour7\">S I E B E N</span>&nbsp;<br />" +
 								"&nbsp;<span id=\"hour3\">D R E I </span><span id=\"hour5\">F Ü N F </span><span id=\"hour11\">E L F</span>&nbsp;<br />" +


### PR DESCRIPTION
Before this change there was the time wrongly shown with
'ES IST EINS UHR'. Correctly it must say: 'ES IST EIN UHR'.

This commit will only omit the 's', when it is one o'clock. Nothing else
changes.